### PR TITLE
Avoid setting up the UI components more than once

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -15,9 +15,9 @@ import {setupClient} from './client';
 import {openBulkAddChannelModal} from './actions';
 
 export default class Plugin {
-    public async initialize(registry: PluginRegistry, store: Store<GlobalState, PluginAction>) {
-        registry.registerReducer(reducers);
+    private setupUIFinished = false;
 
+    public async initialize(registry: PluginRegistry, store: Store<GlobalState, PluginAction>) {
         const setup = async () => {
             setupClient(store.getState() as any as ReduxGlobalState);
 
@@ -29,15 +29,25 @@ export default class Plugin {
             );
 
             registry.registerRootComponent(BulkAddChannelModal);
+
+            this.setupUIFinished = true;
         };
 
-        registry.registerRootComponent(() => <SetupUI setup={setup}/>);
+        registry.registerReducer(reducers);
+        registry.registerRootComponent(() => (
+            <SetupUI
+                setup={setup}
+                setupUIFinished={this.setupUIFinished}
+            />
+        ));
     }
 }
 
-const SetupUI = ({setup}: { setup: () => Promise<void> }) => {
+const SetupUI = ({setup, setupUIFinished}: { setup: () => Promise<void>, setupUIFinished: boolean }) => {
     useEffect(() => {
-        setup();
+        if (!setupUIFinished) {
+            setup();
+        }
     }, []);
 
     return null;


### PR DESCRIPTION
#### Summary
Avoid executing the setup method more than once on the webapp to avoid multiple channel header buttons. 

Fixes #9

