### PR TITLE
Block non-json files in the `input[type=file]`

### DIFF
--- a/webapp/src/components/forms/bulk_add_channel_form.tsx
+++ b/webapp/src/components/forms/bulk_add_channel_form.tsx
@@ -175,6 +175,7 @@ const ActualForm = (props: ActualFormProps) => {
                         }
                     }}
                     type='file'
+                    accept='.json'
                 />
             ),
         },


### PR DESCRIPTION
 #### Summary

Adds the `accept` parameter to the `input[type=file]` so only JSON files can be selected by the browsers. A check is also performed server side.

