### PR TITLE
fix: check guest permissions from config correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This plugin allows you to add users to a channel in bulk by uploading a JSON fil
 - Allows adding users to a channel in bulk by uploading a JSON file.
     - Supports using `user_id` and `username`.
 - (Optionally) Adds the users to the team if they don't belong to it.
-- (Optionally) Invite guest users too, if provied.
 
 ## Installation
 
@@ -47,7 +46,6 @@ After successful installation:
 
     - **File**: Upload a JSON file following the [following format](./.readme/template.jsonc).
     - **Invite members to the team**: If checked, the users will be added to the team if they are not already members. Otherwise they will be skipped.
-    - **Invite guests**: If checked, guest users on the list will be added to the channel (and team if the above is checked). Otherwise they will be skipped.
 
 4. The plugin will display it's progress in the channel:
 

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -23,7 +23,6 @@ func Init(handler *Handler, engine *engine.Engine) {
 type bulkAddChannelPayload struct {
 	ChannelID string           `json:"channel_id"`
 	AddToTeam bool             `json:"add_to_team"`
-	AddGuests bool             `json:"add_guests"`
 	Users     []engine.AddUser `json:"users"`
 }
 
@@ -62,7 +61,6 @@ func (bip *bulkAddChannelPayload) FromRequest(r *http.Request) *perror.PError {
 
 	bip.ChannelID = r.FormValue("channel_id")
 	bip.AddToTeam = r.FormValue("add_to_team") == "true"
-	bip.AddGuests = r.FormValue("add_guests") == "true"
 
 	return nil
 }
@@ -100,7 +98,6 @@ func (h *Handler) channelBulkAddHandler(w http.ResponseWriter, r *http.Request, 
 		UserID:    userID,
 		ChannelID: payload.ChannelID,
 		AddToTeam: payload.AddToTeam,
-		AddGuests: payload.AddGuests,
 		Users:     payload.Users,
 	}
 

--- a/server/engine/engine.go
+++ b/server/engine/engine.go
@@ -58,10 +58,6 @@ func (e *Engine) checkPermissionsForUser(config *Config) *perror.PError {
 		return perror.NewPError(fmt.Errorf("insufficient_team_permissions__add_user"), "You dont have enough permissions to add users to this team")
 	}
 
-	if config.AddToTeam && config.AddGuests && !e.API.HasPermissionToTeam(config.UserID, config.channel.TeamId, model.PermissionInviteGuest) {
-		return perror.NewPError(fmt.Errorf("insufficient_team_permissions__invite_guest"), "You dont have permission to invite guests to this team")
-	}
-
 	return nil
 }
 
@@ -189,7 +185,7 @@ func (e *Engine) addToChannel(userID string, config *Config, result *bulkChannel
 	}
 
 	// Check if user is guest
-	if user.IsGuest() && !config.AddGuests {
+	if user.IsGuest() {
 		e.API.LogInfo("not inviting guest user", "add_user_id", userID, "trigger_user_id", config.UserID, "channel_id", config.ChannelID)
 		result.notAddedGuest++
 		return nil

--- a/server/engine/engine_test.go
+++ b/server/engine/engine_test.go
@@ -20,7 +20,6 @@ func newValidEmptyConfig() *Config {
 		UserID:    "user-id",
 		Users:     []AddUser{},
 		AddToTeam: false,
-		AddGuests: false,
 	}
 }
 

--- a/server/engine/model.go
+++ b/server/engine/model.go
@@ -69,10 +69,4 @@ type Config struct {
 
 	// AddToTeam add users to the team if they do not belong to it
 	AddToTeam bool
-
-	// AddGuests add guests to the team and channel if they do not belong to it
-	AddGuests bool
-
-	// inviteToWorkspace invite the users by email to the workspace if they are not registered
-	// inviteToWorkspace bool
 }

--- a/webapp/src/actions.ts
+++ b/webapp/src/actions.ts
@@ -46,7 +46,6 @@ export const bulkAddToChannel = async (payload: BulkAddChannelPayload): Promise<
     const formData = new FormData();
     formData.append('channel_id', payload.channel_id);
     formData.append('add_to_team', String(payload.add_to_team).toLowerCase());
-    formData.append('add_guests', String(payload.add_guests).toLowerCase());
     if (payload.file) {
         formData.append('file', payload.file);
     }

--- a/webapp/src/components/forms/bulk_add_channel_form.tsx
+++ b/webapp/src/components/forms/bulk_add_channel_form.tsx
@@ -19,7 +19,6 @@ type Props = {
 
 export type BulkAddChannelPayload = {
     add_to_team: boolean;
-    add_guests: boolean;
     file?: File
     users: string[];
     channel_id: string;
@@ -33,7 +32,6 @@ export default function BulkAddChannelForm(props: Props) {
     const [channelName, setChannelName] = useState('');
     const [formValues, setFormValues] = useState<BulkAddChannelPayload>({
         add_to_team: false,
-        add_guests: false,
         users: [],
         channel_id: modalProps?.channelId || '',
     });
@@ -202,26 +200,6 @@ const ActualForm = (props: ActualFormProps) => {
 
                     // disabled={teamAddDisabled}
                     type='checkbox'
-                />
-            ),
-        },
-        {
-            label: 'Add guests',
-            required: false,
-            helpText: (
-                <div>
-                    {'Adds guests, if they are present on the file. If unchecked, guests will not be added to the channel.'}
-                </div>
-            ),
-            element: (
-                <input
-                    id='bulk-add-channel-add-guests'
-                    onChange={(e) => {
-                        setFormValue('add_guests', e.target.checked);
-                    }}
-                    value={String(formValues.add_guests)}
-                    type='checkbox'
-                    checked={formValues.add_guests}
                 />
             ),
         },


### PR DESCRIPTION
#### Summary

Properly check permissions if the user running the bulk invite wants to invite guests from other teams to the channel the same way Mattermost's does.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-55584